### PR TITLE
added codedeploy and elasticache message handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ deps:
 test:
 	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) run -x test/context.json -j test/sns-cloudwatch-event.json
 	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) run -x test/context.json -j test/sns-elastic-beanstalk-event.json
+	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) run -x test/context.json -j test/sns-codedeploy-event.json
+	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) run -x test/context.json -j test/sns-elasticache-event.json
 
 .PHONY: package
 package:

--- a/config.js
+++ b/config.js
@@ -1,0 +1,26 @@
+module.exports = {
+
+  kmsEncryptedHookUrl: "<kmsEncryptedHookUrl>", // encrypted slack webhook url
+  unencryptedHookUrl: "<unencryptedHookUrl>", // unencrypted slack webhook url
+  slackChannel: "#general",  // slack channel to send a message to
+  slackUsername: "AWS SNS via Lamda", // slack username to user for messages
+  region: "us-east-1", // default region for links in services that dont include region in sns
+  icon_emoji: ":robot_face:", // slack emoji icon to use for messages
+  orgIcon: "", // url to icon for your organization for display in the footer of messages
+  orgName: "", // name of your organization for display in the footer of messages
+  services: {
+    elasticbeanstalk: {
+      match_text: "ElasticBeanstalkNotifications" // text in the sns message or topicname to match on to process this service type
+    },
+    cloudwatch: {
+      match_text: "CloudWatchNotifications" // text in the sns message or topicname to match on to process this service type
+    },
+    codedeploy: {
+      match_text: "CodeDeploy" // text in the sns message or topicname to match on to process this service type
+    },
+    elasticache: {
+      match_text: "ElastiCache" // text in the sns message or topicname to match on to process this service type
+    }
+  }
+
+}

--- a/index.js
+++ b/index.js
@@ -1,222 +1,282 @@
-
 var AWS = require('aws-sdk');
 var url = require('url');
 var https = require('https');
-var hookUrl, kmsEncyptedHookUrl, slackChannel;
+var config = require('./config');
+var _ = require('lodash');
+var hookUrl;
 
-// mandatory configuration
-kmsEncyptedHookUrl = '<kmsEncryptedHookUrl>'
-
-unencryptedHookUrl = null
-
-slackChannel = '#dev';  // Enter the Slack channel to send a message to
-
-// optional configuration
-var slackUsername = null
-var orgIcon = null
-
+var baseSlackMessage = {
+  channel: config.slackChannel,
+  username: config.slackUsername,
+  icon_emoji: config.icon_emoji,
+  attachments: [
+    {
+      "footer": config.orgName,
+      "footer_icon": config.orgIcon
+    }
+  ]
+}
 
 var postMessage = function(message, callback) {
-    var body = JSON.stringify(message);
-    var options = url.parse(hookUrl);
-    options.method = 'POST';
-    options.headers = {
-        'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(body),
-    };
+  var body = JSON.stringify(message);
+  var options = url.parse(hookUrl);
+  options.method = 'POST';
+  options.headers = {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(body),
+  };
 
-    var postReq = https.request(options, function(res) {
-        var chunks = [];
-        res.setEncoding('utf8');
-        res.on('data', function(chunk) {
-            return chunks.push(chunk);
-        });
-        res.on('end', function() {
-            var body = chunks.join('');
-            if (callback) {
-                callback({
-                    body: body,
-                    statusCode: res.statusCode,
-                    statusMessage: res.statusMessage
-                });
-            }
-        });
-        return res;
+  var postReq = https.request(options, function(res) {
+    var chunks = [];
+    res.setEncoding('utf8');
+    res.on('data', function(chunk) {
+      return chunks.push(chunk);
     });
+    res.on('end', function() {
+      var body = chunks.join('');
+      if (callback) {
+        callback({
+          body: body,
+          statusCode: res.statusCode,
+          statusMessage: res.statusMessage
+        });
+      }
+    });
+    return res;
+  });
 
-    postReq.write(body);
-    postReq.end();
+  postReq.write(body);
+  postReq.end();
 };
 
 var handleElasticBeanstalk = function(event, context) {
+  var timestamp = (new Date(event.Records[0].Sns.Timestamp)).getTime()/1000;
+  var subject = "AWS Elastic Beanstalk Notification";
+  var message = event.Records[0].Sns.Message;
 
-    console.log(JSON.stringify(event, null, 2));
-    console.log('From SNS:', event.Records[0].Sns.Message);
+  var stateRed = message.indexOf(" to RED");
+  var stateSevere = message.indexOf(" to Severe");
+  var butWithErrors = message.indexOf(" but with errors");
+  var noPermission = message.indexOf("You do not have permission");
+  var failedDeploy = message.indexOf("Failed to deploy application");
+  var failedConfig = message.indexOf("Failed to deploy configuration");
+  var failedQuota = message.indexOf("Your quota allows for 0 more running instance");
+  var unsuccessfulCommand = message.indexOf("Unsuccessful command execution");
 
-    var subject = event.Records[0].Sns.Subject
+  var stateYellow = message.indexOf(" to YELLOW");
+  var stateDegraded = message.indexOf(" to Degraded");
+  var removedInstance = message.indexOf("Removed instance ");
+  var addingInstance = message.indexOf("Adding instance ");
+  var abortedOperation = message.indexOf(" aborted operation.");
+  var abortedDeployment = message.indexOf("some instances may have deployed the new application version");
 
-    var message = event.Records[0].Sns.Message;
+  var color = "good";
 
-    var butWithErrors = message.indexOf(" but with errors");
-    var stateRed = message.indexOf(" to RED");
-    var stateYellow = message.indexOf(" to YELLOW");
-    var noPermission = message.indexOf("You do not have permission");
-    var failedDeploy = message.indexOf("Failed to deploy application");
-    var removedInstance = message.indexOf("Removed instance ");
-    var addingInstance = message.indexOf("Adding instance ");
-    var failedConfig = message.indexOf("Failed to deploy configuration");
-    var failedQuota = message.indexOf("Your quota allows for 0 more running instance");
-    var abortedOperation = message.indexOf(" aborted operation.");
-    var color = "good";
+  if (stateRed != -1 || stateSevere != -1 || butWithErrors != -1 || noPermission != -1 || failedDeploy != -1 || failedConfig != -1 || failedQuota != -1 || unsuccessfulCommand != -1) {
+    color = "danger";
+  }
+  if (stateYellow != -1 || stateDegraded != -1 || removedInstance != -1 || addingInstance != -1 || abortedOperation != -1 || abortedDeployment != -1) {
+    color = "warning";
+  }
 
-    if (stateRed != -1 || butWithErrors != -1 || noPermission != -1 || failedDeploy != -1 || failedConfig != -1 || failedQuota != -1) {
-        color = "danger";
-    }
-    if (stateYellow != -1 || removedInstance != -1 || addingInstance != -1 || abortedOperation != -1) {
-        color = "warning";
-    }
+  var slackMessage = {
+    text: "*" + subject + "*",
+    attachments: [
+      {
+        "fields": [
+          { "title": "Subject", "value": event.Records[0].Sns.Subject},
+          { "title": "Message", "value": message}
+        ],
+        "color": color,
+        "ts":  timestamp
+      }
+    ]
+  };
 
-    var slackMessage = {
-        channel: slackChannel,
-        username: slackUsername || "AWS SNS via Lamda",
-        text: "*" + subject + "*",
-        // text: "*" + event.Records[0].Sns.Subject + "*",
-        icon_emoji: ":aws:",
-        attachments: [
-            {
-                "color": color,
-                "text": message
-            }
-        ]
-    };
+  return _.merge(baseSlackMessage, slackMessage);
+};
 
-    return slackMessage
+var handleCodeDeploy = function(event, context) {
+  var subject = "AWS CodeDeploy Notification";
+  var timestamp = (new Date(event.Records[0].Sns.Timestamp)).getTime()/1000;
+  var snsSubject = event.Records[0].Sns.Subject;
+  var message = JSON.parse(event.Records[0].Sns.Message);
+  var color = "warning";
+
+  if(message.status === "SUCCEEDED"){
+    color = "good";
+  } else if(message.status === "FAILED"){
+    color = "danger";
+  }
+
+  var slackMessage = {
+    text: "*" + subject + "*",
+    attachments: [
+      {
+        "color": color,
+        "fields": [
+          { "title": "Message", "value": snsSubject },
+          { "title": "Deployment Group", "value": message.deploymentGroupName, "short": true },
+          { "title": "Application", "value": message.applicationName, "short": true },
+          {
+            "title": "Status Link",
+            "value": "https://console.aws.amazon.com/codedeploy/home?region=" + message.region + "#/deployments/" + message.deploymentId
+          }
+        ],
+        "ts": timestamp
+      }
+    ]
+  };
+
+  return _.merge(baseSlackMessage, slackMessage);
+};
+
+var handleElasticache = function(event, context) {
+  var subject = "AWS ElastiCache Notification"
+  var message = JSON.parse(event.Records[0].Sns.Message);
+  var timestamp = (new Date(event.Records[0].Sns.Timestamp)).getTime()/1000;
+  var eventname, nodename;
+  var color = "good";
+
+  for(key in message){
+    eventname = key;
+    nodename = message[key];
+    break;
+  }
+  var slackMessage = {
+    text: "*" + subject + "*",
+    attachments: [
+      {
+        "color": color,
+        "fields": [
+          { "title": "Event", "value": eventname.split(":")[1], "short": true },
+          { "title": "Node", "value": nodename, "short": true },
+          {
+            "title": "Link to cache node",
+            "value": "https://console.aws.amazon.com/elasticache/home?region=" + config.region + "#cache-nodes:id=" + nodename + ";nodes"
+          }
+        ],
+        "ts": timestamp
+      }
+    ]
+  };
+  return _.merge(baseSlackMessage, slackMessage);
 };
 
 var handleCloudWatch = function(event, context) {
+  var timestamp = (new Date(event.Records[0].Sns.Timestamp)).getTime()/1000;
+  var message = JSON.parse(event.Records[0].Sns.Message);
+  var subject = "AWS CloudWatch Notification";
+  var alarmName = message.AlarmName;
+  var metricName = message.Trigger.MetricName;
+  var oldState = message.OldStateValue;
+  var newState = message.NewStateValue;
+  var alarmDescription = message.AlarmDescription;
+  var alarmReason = message.NewStateReason;
+  var trigger = message.Trigger;
+  var color = "warning";
 
-    var message = JSON.parse(event.Records[0].Sns.Message);
+  if (message.NewStateValue === "ALARM") {
+      color = "danger";
+  } else if (message.NewStateValue === "OK") {
+      color = "good";
+  }
 
-    var alarmName = message.AlarmName;
-    var metricName = message.Trigger.MetricName;
-    //var oldState = message.OldStateValue;
-    var newState = message.NewStateValue;
-    var reason = message.NewStateReason;
-    var alarmDescription = message.AlarmDescription;
-    var alarmReason = message.NewStateReason;
+  var slackMessage = {
+    text: "*" + subject + "*",
+    attachments: [
+      {
+        "color": color,
+        "fields": [
+          { "title": "Alarm Name", "value": alarmName, "short": true },
+          { "title": "Alarm Description", "value": alarmReason},
+          {
+            "title": "Trigger",
+            "value": trigger.Statistic + " "
+              + metricName + " "
+              + trigger.ComparisonOperator + " "
+              + trigger.Threshold + " for "
+              + trigger.EvaluationPeriods + " period(s) of "
+              + trigger.Period + " seconds."
+          },
+          { "title": "Old State", "value": oldState, "short": true },
+          { "title": "Current State", "value": newState, "short": true },
+          {
+            "title": "Link to Alarm",
+            "value": "https://console.aws.amazon.com/cloudwatch/home?region=" + config.region + "#alarm:alarmFilter=ANY;name=" + alarmName
+          }
+        ],
+        "ts":  timestamp
+      }
+    ]
+  };
 
-    var color = "warning";
-
-    if (message.NewStateValue === "ALARM") {
-        color = "danger";
-    } else if (message.NewStateValue === "OK") {
-        color = "good";
-    }
-
-    var slackMessage = {
-        channel: slackChannel,
-        username: slackUsername || "AWS SNS via Lamda",
-        text: "*" + metricName + " state is now " + newState + "*",
-        // text: "*" + event.Records[0].Sns.Subject + "*",
-        icon_emoji: ":aws:",
-        attachments: [
-            {
-                "fallback":  message.Trigger.Statistic + " "
-                    + metricName + " "
-                    + message.Trigger.ComparisonOperator + " "
-                    + message.Trigger.Threshold,
-                "color": color,
-                // "pretext": "Optional text that appears above the attachment block",
-                "author_name": alarmName,
-                // "author_link": "http://flickr.com/bobby/",
-                // "author_icon": "http://flickr.com/icons/bobby.jpg",
-                "title": alarmDescription,
-                "title_link": "https://api.slack.com/",
-                "text": alarmReason,
-                "fields": [
-                    {
-                        "title": "Trigger",
-                        "value": message.Trigger.Statistic + " "
-                            + metricName + " "
-                            + message.Trigger.ComparisonOperator + " "
-                            + message.Trigger.Threshold,
-                        // "short": false
-                    },
-                    {
-                        "title": "Old State",
-                        "value": message.OldStateValue,
-                        // "short": false
-                    }
-                ],
-                // "image_url": "http://my-website.com/path/to/image.jpg",
-                // "thumb_url": "http://example.com/path/to/thumb.png",
-                "footer": message.Region,
-                "footer_icon": orgIcon,
-                "ts":  (new Date(message.StateChangeTime)).getTime()
-            }
-        ]
-    };
-
-    return slackMessage
+  return _.merge(baseSlackMessage, slackMessage);
 };
 
 var processEvent = function(event, context) {
+  console.log("sns received:" + JSON.stringify(event, null, 2));
+  var slackMessage = null;
+  var eventSubscriptionArn = event.Records[0].EventSubscriptionArn;
+  var eventSnsSubject = event.Records[0].Sns.Subject || 'no subject';
+  var eventSnsMessage = event.Records[0].Sns.Message;
 
-    var slackMessage = null;
-    try {
-        var message = JSON.parse(event.Records[0].Sns.Message);
-        slackMessage = handleCloudWatch(event,context);
-    } catch (e) {
-        slackMessage = handleElasticBeanstalk(event,context)
+  if(eventSubscriptionArn.indexOf(config.services.elasticbeanstalk.match_text) > -1 || eventSnsSubject.indexOf(config.services.elasticbeanstalk.match_text) > -1 || eventSnsMessage.indexOf(config.services.elasticbeanstalk.match_text) > -1){
+    console.log("processing elasticbeanstalk notification");
+    slackMessage = handleElasticBeanstalk(event,context)
+  }
+  else if(eventSubscriptionArn.indexOf(config.services.cloudwatch.match_text) > -1 || eventSnsSubject.indexOf(config.services.cloudwatch.match_text) > -1 || eventSnsMessage.indexOf(config.services.cloudwatch.match_text) > -1){
+    console.log("processing cloudwatch notification");
+    slackMessage = handleCloudWatch(event,context);
+  }
+  else if(eventSubscriptionArn.indexOf(config.services.codedeploy.match_text) > -1 || eventSnsSubject.indexOf(config.services.codedeploy.match_text) > -1 || eventSnsMessage.indexOf(config.services.codedeploy.match_text) > -1){
+    console.log("processing codedeploy notification");
+    slackMessage = handleCodeDeploy(event,context);
+  }
+  else if(eventSubscriptionArn.indexOf(config.services.elasticache.match_text) > -1 || eventSnsSubject.indexOf(config.services.elasticache.match_text) > -1 || eventSnsMessage.indexOf(config.services.elasticache.match_text) > -1){
+    console.log("processing elasticache notification");
+    slackMessage = handleElasticache(event,context);
+  }
+  else{
+    context.fail("no matching processor for event");
+  }
+
+  postMessage(slackMessage, function(response) {
+    if (response.statusCode < 400) {
+      console.info('message posted successfully');
+      context.succeed();
+    } else if (response.statusCode < 500) {
+      console.error("error posting message to slack API: " + response.statusCode + " - " + response.statusMessage);
+      // Don't retry because the error is due to a problem with the request
+      context.succeed();
+    } else {
+      // Let Lambda retry
+      context.fail("server error when processing message: " + response.statusCode + " - " + response.statusMessage);
     }
-
-    postMessage(slackMessage, function(response) {
-        if (response.statusCode < 400) {
-            console.info('Message posted successfully');
-            context.succeed();
-        } else if (response.statusCode < 500) {
-            console.error("Error posting message to Slack API: "
-                          + response.statusCode + " - "
-                          + response.statusMessage);
-
-            // Don't retry because the error is due to a problem with the request
-            context.succeed();
-        } else {
-            // Let Lambda retry
-            context.fail("Server error when processing message: "
-                         + response.statusCode + " - "
-                         + response.statusMessage);
-        }
-    });
+  });
 };
 
-
 exports.handler = function(event, context) {
-    if (hookUrl) {
-        // Container reuse, simply process the event with the key in memory
+  if (hookUrl) {
+    processEvent(event, context);
+  } else if (config.unencryptedHookUrl) {
+    hookUrl = config.unencryptedHookUrl;
+    processEvent(event, context);
+  } else if (config.kmsEncryptedHookUrl && config.kmsEncryptedHookUrl !== '<kmsEncryptedHookUrl>') {
+    var encryptedBuf = new Buffer(config.kmsEncryptedHookUrl, 'base64');
+    var cipherText = { CiphertextBlob: encryptedBuf };
+    var kms = new AWS.KMS();
+
+    kms.decrypt(cipherText, function(err, data) {
+      if (err) {
+        console.log("decrypt error: " + err);
         processEvent(event, context);
-
-    } else if (unencryptedHookUrl) {
-
-        hookUrl = unencryptedHookUrl;
+      } else {
+        hookUrl = "https://" + data.Plaintext.toString('ascii');
         processEvent(event, context);
-
-    } else if (kmsEncyptedHookUrl && kmsEncyptedHookUrl !== '<kmsEncryptedHookUrl>') {
-
-        var encryptedBuf = new Buffer(kmsEncyptedHookUrl, 'base64');
-        var cipherText = { CiphertextBlob: encryptedBuf };
-        var kms = new AWS.KMS();
-
-        kms.decrypt(cipherText, function(err, data) {
-            if (err) {
-                console.log("Decrypt error: " + err);
-                processEvent(event, context);
-            } else {
-                hookUrl = "https://" + data.Plaintext.toString('ascii');
-                processEvent(event, context);
-            }
-        });
-    } else {
-        context.fail('Hook URL has not been set.');
-    }
+      }
+    });
+  } else {
+    context.fail('hook url has not been set.');
+  }
 };

--- a/index.js
+++ b/index.js
@@ -84,8 +84,8 @@ var handleElasticBeanstalk = function(event, context) {
     attachments: [
       {
         "fields": [
-          { "title": "Subject", "value": event.Records[0].Sns.Subject},
-          { "title": "Message", "value": message}
+          { "title": "Subject", "value": event.Records[0].Sns.Subject, "short": false},
+          { "title": "Message", "value": message, "short": false}
         ],
         "color": color,
         "ts":  timestamp
@@ -115,12 +115,13 @@ var handleCodeDeploy = function(event, context) {
       {
         "color": color,
         "fields": [
-          { "title": "Message", "value": snsSubject },
+          { "title": "Message", "value": snsSubject, "short": false },
           { "title": "Deployment Group", "value": message.deploymentGroupName, "short": true },
           { "title": "Application", "value": message.applicationName, "short": true },
           {
             "title": "Status Link",
-            "value": "https://console.aws.amazon.com/codedeploy/home?region=" + message.region + "#/deployments/" + message.deploymentId
+            "value": "https://console.aws.amazon.com/codedeploy/home?region=" + message.region + "#/deployments/" + message.deploymentId,
+            "short": false
           }
         ],
         "ts": timestamp
@@ -153,7 +154,8 @@ var handleElasticache = function(event, context) {
           { "title": "Node", "value": nodename, "short": true },
           {
             "title": "Link to cache node",
-            "value": "https://console.aws.amazon.com/elasticache/home?region=" + config.region + "#cache-nodes:id=" + nodename + ";nodes"
+            "value": "https://console.aws.amazon.com/elasticache/home?region=" + config.region + "#cache-nodes:id=" + nodename + ";nodes",
+            "short": false
           }
         ],
         "ts": timestamp
@@ -189,7 +191,7 @@ var handleCloudWatch = function(event, context) {
         "color": color,
         "fields": [
           { "title": "Alarm Name", "value": alarmName, "short": true },
-          { "title": "Alarm Description", "value": alarmReason},
+          { "title": "Alarm Description", "value": alarmReason, "short": false},
           {
             "title": "Trigger",
             "value": trigger.Statistic + " "
@@ -197,13 +199,15 @@ var handleCloudWatch = function(event, context) {
               + trigger.ComparisonOperator + " "
               + trigger.Threshold + " for "
               + trigger.EvaluationPeriods + " period(s) of "
-              + trigger.Period + " seconds."
+              + trigger.Period + " seconds.",
+              "short": false
           },
           { "title": "Old State", "value": oldState, "short": true },
           { "title": "Current State", "value": newState, "short": true },
           {
             "title": "Link to Alarm",
-            "value": "https://console.aws.amazon.com/cloudwatch/home?region=" + config.region + "#alarm:alarmFilter=ANY;name=" + alarmName
+            "value": "https://console.aws.amazon.com/cloudwatch/home?region=" + config.region + "#alarm:alarmFilter=ANY;name=" + alarmName,
+            "short": false
           }
         ],
         "ts":  timestamp

--- a/index.js
+++ b/index.js
@@ -210,7 +210,6 @@ var handleCloudWatch = function(event, context) {
       }
     ]
   };
-
   return _.merge(baseSlackMessage, slackMessage);
 };
 

--- a/package.json
+++ b/package.json
@@ -3,28 +3,29 @@
   "version": "0.0.3",
   "description": "Better Slack notifications for AWS CloudWatch",
   "authors": [
-      "Assertible <admin@assertible.com>",
-      "Christopher Reichert <creichert07@gmail.com>",
-      "Cody Reichert <codyreichert@gmail.com>"
+    "Assertible <admin@assertible.com>",
+    "Christopher Reichert <creichert07@gmail.com>",
+    "Cody Reichert <codyreichert@gmail.com>"
   ],
   "config": {
     "progress": "true"
   },
   "dependencies": {
-      "aws-sdk": "^2.4.0",
-      "url": "^0.11.0",
-      "https": "^1.0.0"
+    "aws-sdk": "^2.4.0",
+    "https": "^1.0.0",
+    "lodash": "^4.14.2",
+    "url": "^0.11.0"
   },
   "devDependencies": {
     "node-lambda": "^0.8.6"
   },
   "keywords": [
-      "aws",
-      "slack",
-      "lambda",
-      "slackbot",
-      "cloudwatch",
-      "notifications"
+    "aws",
+    "slack",
+    "lambda",
+    "slackbot",
+    "cloudwatch",
+    "notifications"
   ],
   "license": "MIT"
 }

--- a/test/sns-cloudwatch-event.json
+++ b/test/sns-cloudwatch-event.json
@@ -1,18 +1,18 @@
 {
-    "Records": [
-        {
-            "EventSource": "aws:sns",
-            "EventVersion": "1.0",
-            "EventSubscriptionArn": "arn:aws:sns:us-west-2:123456789123:ElasticBeanstalkNotifications-Environment-app-staging:00000000-0000-0000-0000-000000000000",
-            "Sns": {
-                "Type": "Notification",
-                "MessageId": "00000000-0000-0000-0000-000000000000",
-                "TopicArn": "arn:aws:sns:us-west-2:123456789123:ElasticBeanstalkNotifications-Environment-app-staging",
-                "Subject": "ALARM: \"awsrds-app-High-DB-Connections\" in US West - Oregon",
-                "Message": "{\"AlarmName\":\"awsrds-app-High-DB-Connections\",\"AlarmDescription\":null,\"AWSAccountId\":\"123456789123\",\"NewStateValue\":\"ALARM\",\"NewStateReason\":\"Threshold Crossed: 1 datapoint (10.0) was greater than or equal to the threshold (10.0).\",\"StateChangeTime\":\"2016-07-24T22:05:19.737+0000\",\"Region\":\"US West - Oregon\",\"OldStateValue\":\"OK\",\"Trigger\":{\"MetricName\":\"DatabaseConnections\",\"Namespace\":\"AWS/RDS\",\"Statistic\":\"AVERAGE\",\"Unit\":null,\"Dimensions\":[{\"name\":\"DBInstanceIdentifier\",\"value\":\"app\"}],\"Period\":300,\"EvaluationPeriods\":1,\"ComparisonOperator\":\"GreaterThanOrEqualToThreshold\",\"Threshold\":10.0}}"
-                , "MessageAttributes": {}
-            }
-
-        }
-    ]
+  "Records": [
+    {
+      "EventSource": "aws:sns",
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:us-west-2:123456789123:CloudWatchNotifications:00000000-0000-0000-0000-000000000000",
+      "Sns": {
+        "Type": "Notification",
+        "MessageId": "00000000-0000-0000-0000-000000000000",
+        "TopicArn": "arn:aws:sns:us-west-2:123456789123:CloudWatchNotifications",
+        "Timestamp": "2016-08-11T07:24:05.959Z",
+        "Subject": "ALARM: \"awsrds-app-High-DB-Connections\" in US West - Oregon",
+        "Message": "{\"AlarmName\":\"awsrds-app-High-DB-Connections\",\"AlarmDescription\":null,\"AWSAccountId\":\"123456789123\",\"NewStateValue\":\"ALARM\",\"NewStateReason\":\"Threshold Crossed: 1 datapoint (10.0) was greater than or equal to the threshold (10.0).\",\"StateChangeTime\":\"2016-07-24T22:05:19.737+0000\",\"Region\":\"US West - Oregon\",\"OldStateValue\":\"OK\",\"Trigger\":{\"MetricName\":\"DatabaseConnections\",\"Namespace\":\"AWS/RDS\",\"Statistic\":\"AVERAGE\",\"Unit\":null,\"Dimensions\":[{\"name\":\"DBInstanceIdentifier\",\"value\":\"app\"}],\"Period\":300,\"EvaluationPeriods\":1,\"ComparisonOperator\":\"GreaterThanOrEqualToThreshold\",\"Threshold\":10.0}}",
+        "MessageAttributes": {}
+      }
+    }
+  ]
 }

--- a/test/sns-codedeploy-event.json
+++ b/test/sns-codedeploy-event.json
@@ -1,0 +1,18 @@
+{
+  "Records": [
+    {
+      "EventSource": "aws:sns",
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:us-east-1:123456789123:CodeDeployNotifications:00000000-0000-0000-0000-000000000000",
+      "Sns": {
+        "Type": "Notification",
+        "MessageId": "00000000-0000-0000-0000-000000000000",
+        "TopicArn": "arn:aws:sns:us-east-1:123456789:CodeDeployNotifications",
+        "Subject": "SUCCEEDED: AWS CodeDeploy d-123ABC456 in us-east-1 to your-application-name",
+        "Message": "{\"region\":\"us-east-1\",\"accountId\":\"123456789\",\"eventTriggerName\":\"notify team\",\"applicationName\":\"your-application-name\",\"deploymentId\":\"d-123ABC456\",\"deploymentGroupName\":\"your-application-name-group\",\"createTime\":\"Wed Aug 10 18:39:05 UTC 2016\",\"completeTime\":\"Wed Aug 10 18:40:33 UTC 2016\",\"deploymentOverview\":\"{\\\"Succeeded\\\":1,\\\"Failed\\\":0,\\\"Skipped\\\":0,\\\"InProgress\\\":0,\\\"Pending\\\":0}\",\"status\":\"SUCCEEDED\"}",
+        "Timestamp": "2016-08-10T19:12:12.411Z",
+        "MessageAttributes": {}
+      }
+    }
+  ]
+}

--- a/test/sns-elastic-beanstalk-event.json
+++ b/test/sns-elastic-beanstalk-event.json
@@ -3,12 +3,12 @@
     {
       "Sns": {
         "MessageAttributes": null,
-        "UnsubscribeUrl": "https:\/\/sns.us-west-2.amazonaws.com\/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-west-2:123456789123:ElasticBeanstalkNotifications-Environment-app-staging:00000000-0000-0000-0000-000000000000",
         "Message": "Timestamp: Sun Jul 24 20:37:10 UTC 2016\nMessage: Environment health has transitioned from Ok to Degraded. 5.0 % of the requests are failing with HTTP 5xx.\n\nEnvironment: retsd-staging-1\nApplication: retsd\n\nEnvironment URL: http:\/\/app-staging.us-west-2.elasticbeanstalk.com\nNotificationProcessId: 00000000-0000-0000-0000-000000000000",
         "Subject": "AWS Elastic Beanstalk Notification - Environment health has transitioned from Ok to Degraded. 5.0...",
         "TopicArn": "arn:aws:sns:us-west-2:123456789:ElasticBeanstalkNotifications-Environment-app-staging",
         "MessageId": "00000000-0000-0000-0000-000000000000",
-        "Type": "Notification"
+        "Type": "Notification",
+        "Timestamp": "2016-08-11T07:24:05.959Z"
       },
       "EventSubscriptionArn": "arn:aws:sns:us-west-2:123456789123:ElasticBeanstalkNotifications-Environment-app-staging:00000000-0000-0000-0000-000000000000",
       "EventVersion": "1.0",

--- a/test/sns-elasticache-event.json
+++ b/test/sns-elasticache-event.json
@@ -1,0 +1,18 @@
+{
+  "Records": [
+    {
+      "EventSource": "aws:sns",
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:us-east-1:123456789123:ElasticacheNotifications:00000000-0000-0000-0000-000000000000",
+      "Sns": {
+        "Type": "Notification",
+        "MessageId": "7f660149-f0b8-53a4-83c5-516fdaed6a4b",
+        "TopicArn": "arn:aws:sns:us-east-1:123456789123:ElasticacheNotifications",
+        "Subject": null,
+        "Message": "{\"ElastiCache:ElasticacheEvent\":\"nodename\"}",
+        "Timestamp": "2016-08-11T07:24:05.959Z",
+        "MessageAttributes": {}
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This module was super useful as a starting point for our org to get some aws sns messages into slack, but was missing some basic things that we needed (elasticache/codedeploy messaging). Not sure if you guys want to move in the direction of making this an all in one sns solution or not but that is something I'm planning on doing using this as a baseline. Figured I'd submit the PR for feedback and if you don't want to move in that direction, I'll just build on top of it in the fork for us.

I slso extracted the config to its own template so it wasn't as confusing on what i should or should not change in the base lambda handler