### PR TITLE
fixed bug with codedeploy notifications and added autoscaling support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,9 @@ test:
 	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) run -x test/context.json -j test/sns-cloudwatch-event.json
 	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) run -x test/context.json -j test/sns-elastic-beanstalk-event.json
 	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) run -x test/context.json -j test/sns-codedeploy-event.json
+	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) run -x test/context.json -j test/sns-codedeploy-configuration.json
 	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) run -x test/context.json -j test/sns-elasticache-event.json
+	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) run -x test/context.json -j test/sns-autoscaling-event.json
 
 .PHONY: package
 package:

--- a/config.js
+++ b/config.js
@@ -20,6 +20,9 @@ module.exports = {
     },
     elasticache: {
       match_text: "ElastiCache" // text in the sns message or topicname to match on to process this service type
+    },
+    autoscaling: {
+      match_text: "AutoScaling" // text in the sns message or topicname to match on to process this service type
     }
   }
 

--- a/test/sns-autoscaling-event.json
+++ b/test/sns-autoscaling-event.json
@@ -1,0 +1,18 @@
+{
+    "Records": [
+        {
+            "EventSource": "aws:sns",
+            "EventVersion": "1.0",
+            "EventSubscriptionArn": "arn:aws:sns:us-east-1:123456789123:AutoScalingNotifications:00000000-0000-0000-0000-000000000000",
+            "Sns": {
+                "Type": "Notification",
+                "MessageId": "00000000-0000-0000-0000-000000000000",
+                "TopicArn": "arn:aws:sns:us-east-1:123456789:AutoScalingNotifications",
+                "Subject": "Auto Scaling: termination for group \"autoscale-group-name\"",
+                "Message": "{\"Progress\":50,\"AccountId\":\"123456789123\",\"Description\":\"Terminating EC2 instance: i-00000000\",\"RequestId\":\"00000000-0000-0000-0000-000000000000\",\"EndTime\":\"2016-09-16T12:39:01.604Z\",\"AutoScalingGroupARN\":\"arn:aws:autoscaling:us-east-1:123456789:autoScalingGroup:00000000-0000-0000-0000-000000000000:autoScalingGroupName/autoscale-group-name\",\"ActivityId\":\"00000000-0000-0000-0000-000000000000\",\"StartTime\":\"2016-09-16T12:37:39.004Z\",\"Service\":\"AWS Auto Scaling\",\"Time\":\"2016-09-16T12:39:01.604Z\",\"EC2InstanceId\":\"i-00000000\",\"StatusCode\":\"InProgress\",\"StatusMessage\":\"\",\"Details\":{\"Subnet ID\":\"subnet-00000000\",\"Availability Zone\":\"us-east-1a\"},\"AutoScalingGroupName\":\"autoscale-group-name\",\"Cause\":\"At 2016-09-16T12:37:09Z a user request update of AutoScalingGroup constraints to min: 0, max: 0, desired: 0 changing the desired capacity from 1 to 0.  At 2016-09-16T12:37:38Z an instance was taken out of service in response to a difference between desired and actual capacity, shrinking the capacity from 1 to 0.  At 2016-09-16T12:37:39Z instance i-00000000 was selected for termination.\",\"Event\":\"autoscaling:EC2_INSTANCE_TERMINATE\"}",
+                "Timestamp": "2016-09-16T12:39:01.661Z",
+                "MessageAttributes": {}
+            }
+        }
+    ]
+}

--- a/test/sns-codedeploy-configuration.json
+++ b/test/sns-codedeploy-configuration.json
@@ -1,0 +1,18 @@
+{
+    "Records": [
+        {
+            "EventSource": "aws:sns",
+            "EventVersion": "1.0",
+            "EventSubscriptionArn": "arn:aws:sns:us-east-1:123456789123:CodeDeployNotifications:00000000-0000-0000-0000-000000000000",
+            "Sns": {
+                "Type": "Notification",
+                "MessageId": "00000000-0000-0000-0000-000000000000",
+                "TopicArn": "arn:aws:sns:us-east-1:123456789:CodeDeployNotifications",
+                "Subject": "SUCCESS: AWS CodeDeploy notification setup for trigger CodeDeployNotifications",
+                "Message": "Your AWS CodeDeploy trigger arn:aws:sns:us-east-1:123456789123:CodeDeployNotifications is able to send notifications for the SNS topic you specified.\nAll subscribers to the topic will receive notifications related to the events you specified for this trigger.\nThank you,\nThe AWS CodeDeploy Service Team",
+                "Timestamp": "2016-09-15T16:46:11.645Z",                
+                "MessageAttributes": {}
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Issues/Changes
1. There was a status for ELB notifications that was an incorrect color when status went "to info" -- changed to yellow
2. There was an error parsing message when setting up new CodeDeploy deployment groups and setting up notifications the first time because the message in the sns was text and not json -- added handling to fallback to text if not parseable
3. Added AutoScaling SNS support
4. Added tests for (2) and (3)