### PR TITLE
Set AWS_PROFILE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,5 @@ deploy:
 				--role $(AWS_ROLE) \
 				--accessKey $(AWS_ACCESS_KEY_ID) \
 				--secretKey $(AWS_ACCESS_KEY_SECRET) \
-				--region $(AWS_REGION)
+				--region $(AWS_REGION) \
+				--profile $(AWS_PROFILE)


### PR DESCRIPTION
My AWS credentials file has 2 profiles in it, i.e.:
```
$ cat ~/.aws/credentials 
[default]
aws_access_key_id = ...
aws_secret_access_key = ...
region=us-east-1
[otheruser]
aws_access_key_id = ...
aws_secret_access_key = ...
region=us-east-1
```
I observed that setting `AWS_PROFILE` in the makefile was not taking effect. I had to add `--profile` to the deploy command.