### PR TITLE
get regions from sns subscription arn instead of config

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,7 +4,6 @@ module.exports = {
   unencryptedHookUrl: "<unencryptedHookUrl>", // unencrypted slack webhook url
   slackChannel: "#general",  // slack channel to send a message to
   slackUsername: "AWS SNS via Lamda", // slack username to user for messages
-  region: "us-east-1", // default region for links in services that dont include region in sns
   icon_emoji: ":robot_face:", // slack emoji icon to use for messages
   orgIcon: "", // url to icon for your organization for display in the footer of messages
   orgName: "", // name of your organization for display in the footer of messages

--- a/index.js
+++ b/index.js
@@ -148,6 +148,7 @@ var handleElasticache = function(event, context) {
   var subject = "AWS ElastiCache Notification"
   var message = JSON.parse(event.Records[0].Sns.Message);
   var timestamp = (new Date(event.Records[0].Sns.Timestamp)).getTime()/1000;
+  var region = event.Records[0].EventSubscriptionArn.split(":")[3];
   var eventname, nodename;
   var color = "good";
 
@@ -166,7 +167,7 @@ var handleElasticache = function(event, context) {
           { "title": "Node", "value": nodename, "short": true },
           {
             "title": "Link to cache node",
-            "value": "https://console.aws.amazon.com/elasticache/home?region=" + config.region + "#cache-nodes:id=" + nodename + ";nodes",
+            "value": "https://console.aws.amazon.com/elasticache/home?region=" + region + "#cache-nodes:id=" + nodename + ";nodes",
             "short": false
           }
         ],
@@ -180,6 +181,7 @@ var handleElasticache = function(event, context) {
 var handleCloudWatch = function(event, context) {
   var timestamp = (new Date(event.Records[0].Sns.Timestamp)).getTime()/1000;
   var message = JSON.parse(event.Records[0].Sns.Message);
+  var region = event.Records[0].EventSubscriptionArn.split(":")[3];
   var subject = "AWS CloudWatch Notification";
   var alarmName = message.AlarmName;
   var metricName = message.Trigger.MetricName;
@@ -218,7 +220,7 @@ var handleCloudWatch = function(event, context) {
           { "title": "Current State", "value": newState, "short": true },
           {
             "title": "Link to Alarm",
-            "value": "https://console.aws.amazon.com/cloudwatch/home?region=" + config.region + "#alarm:alarmFilter=ANY;name=" + alarmName,
+            "value": "https://console.aws.amazon.com/cloudwatch/home?region=" + region + "#alarm:alarmFilter=ANY;name=" + alarmName,
             "short": false
           }
         ],


### PR DESCRIPTION
This allows for multi-region support of services without having to hardcode the region in the config file. The region is read from the subscription arn of the SNS (this is used for the links in the SNS messages)