### PR TITLE
Add better debugging when no matching process is found

### DIFF
--- a/index.js
+++ b/index.js
@@ -290,7 +290,7 @@ var processEvent = function(event, context) {
     slackMessage = handleAutoScaling(event, context);
   }
   else{
-    context.fail("no matching processor for event");
+    context.fail("No matching processor for event. [EventSubscriptionArn: " + eventSubscriptionArn + "]");
   }
 
   postMessage(slackMessage, function(response) {


### PR DESCRIPTION
This just adds better debug when there is no matching processor for the event. It should make it easier to report issues and find the unsupported topic. Ref #7 