### PR TITLE
Update config to use Lambda environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ AWS_PROFILE=myprofile
 
 ### 2. Configure AWS Lambda script
 
-Next, open `config.js`. there are several mandatory and optional
-configuration options. We've tried to choose a good set of defaults:
+Most of the configurations to this package are made through Lambda environment variables.  Open the `config.js`
+file to get the names of the environment variables that can be set.  There are several mandatory and optional
+configuration options.  We've tried to choose a good set of defaults:
 
 
 #### a. mandatory configuration

--- a/config.js
+++ b/config.js
@@ -1,27 +1,32 @@
 module.exports = {
 
-  kmsEncryptedHookUrl: "<kmsEncryptedHookUrl>", // encrypted slack webhook url
-  unencryptedHookUrl: "<unencryptedHookUrl>", // unencrypted slack webhook url
-  slackChannel: "#general",  // slack channel to send a message to
-  slackUsername: "AWS SNS via Lamda", // slack username to user for messages
-  icon_emoji: ":robot_face:", // slack emoji icon to use for messages
-  orgIcon: "", // url to icon for your organization for display in the footer of messages
-  orgName: "", // name of your organization for display in the footer of messages
+  kmsEncryptedHookUrl: process.env.kmsEncryptedHookUrl, // encrypted slack webhook url
+  unencryptedHookUrl: process.env.unencryptedHookUrl,   // unencrypted slack webhook url
+  slackChannel: process.env.slackChannel,      // slack channel to send a message to
+  slackUsername: process.env.slackUsername,    // slack username to user for messages
+  icon_emoji: process.env.icon_emoji,          // slack emoji icon to use for messages
+  orgIcon: process.env.orgIcon,                // url to icon for your organization for display in the footer of messages
+  orgName: process.env.orgName,                // name of your organization for display in the footer of messages
   services: {
     elasticbeanstalk: {
-      match_text: "ElasticBeanstalkNotifications" // text in the sns message or topicname to match on to process this service type
+      // text in the sns message or topicname to match on to process this service type
+      match_text: "ElasticBeanstalkNotifications"
     },
     cloudwatch: {
-      match_text: "CloudWatchNotifications" // text in the sns message or topicname to match on to process this service type
+      // text in the sns message or topicname to match on to process this service type
+      match_text: "CloudWatchNotifications"
     },
     codedeploy: {
-      match_text: "CodeDeploy" // text in the sns message or topicname to match on to process this service type
+      // text in the sns message or topicname to match on to process this service type
+      match_text: "CodeDeploy"
     },
     elasticache: {
-      match_text: "ElastiCache" // text in the sns message or topicname to match on to process this service type
+      // text in the sns message or topicname to match on to process this service type
+      match_text: "ElastiCache"
     },
     autoscaling: {
-      match_text: "AutoScaling" // text in the sns message or topicname to match on to process this service type
+      // text in the sns message or topicname to match on to process this service type
+      match_text: "AutoScaling"
     }
   }
 


### PR DESCRIPTION
Since Lambda gained support for environment variables I thought it would be nice to use it instead of hardcoding the values in `config.js`.  This simple PR just replaces the static entries with a call to process.env.  

I also updated the comments so they fit into 130 columns and added a bit to the README.  :)