### PR TITLE
Pin node-lambda package to 0.8.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-cloudwatch-slack",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Better Slack notifications for AWS CloudWatch",
   "authors": [
     "Assertible <admin@assertible.com>",
@@ -17,7 +17,7 @@
     "url": "^0.11.0"
   },
   "devDependencies": {
-    "node-lambda": "^0.8.6"
+    "node-lambda": "0.8.11"
   },
   "keywords": [
     "aws",


### PR DESCRIPTION
In the newer versions of `node-lambda` the `context.suceed` and
`context.done` methods have been deprecated, but we use those
functions (for now) still. This pins that package to version 0.8.11,
which has the functionality we need.

Fixes #12
Ref: https://github.com/motdotla/node-lambda/issues/223