### PR TITLE
Change slack message object merge order to fix bug with lambda container re-use

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ var handleElasticBeanstalk = function(event, context) {
     ]
   };
 
-  return _.merge(baseSlackMessage, slackMessage);
+  return _.merge(slackMessage, baseSlackMessage);
 };
 
 var handleCodeDeploy = function(event, context) {
@@ -141,7 +141,7 @@ var handleCodeDeploy = function(event, context) {
     ]
   };
 
-  return _.merge(baseSlackMessage, slackMessage);
+  return _.merge(slackMessage, baseSlackMessage);
 };
 
 var handleElasticache = function(event, context) {
@@ -175,7 +175,7 @@ var handleElasticache = function(event, context) {
       }
     ]
   };
-  return _.merge(baseSlackMessage, slackMessage);
+  return _.merge(slackMessage, baseSlackMessage);
 };
 
 var handleCloudWatch = function(event, context) {
@@ -228,7 +228,7 @@ var handleCloudWatch = function(event, context) {
       }
     ]
   };
-  return _.merge(baseSlackMessage, slackMessage);
+  return _.merge(slackMessage, baseSlackMessage);
 };
 
 var handleAutoScaling = function(event, context) {
@@ -259,7 +259,7 @@ var handleAutoScaling = function(event, context) {
       }
     ]
   };
-  return _.merge(baseSlackMessage, slackMessage);
+  return _.merge(slackMessage, baseSlackMessage);
 };
 
 var processEvent = function(event, context) {


### PR DESCRIPTION
When Lambda re-uses a container, global variables in a javascript file will retain state. Since _.merge was called with baseSlackMessage as the 1st parameter, it was being modified and then retaining keys of the last sent message on a subsequent call.

![slackmessagebug](https://cloud.githubusercontent.com/assets/3117973/25859763/8c4920bc-34ad-11e7-8aa9-296620405efa.png)

I made a simple fix that changes the message object merge order, so the global baseSlackMessage is not modified in the process.