### PR TITLE
Use environment variables to store user configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 .env
+deploy.env
 npm-debug.log
 
 build/

--- a/README.md
+++ b/README.md
@@ -49,39 +49,10 @@ variables may look like this:
 LAMBDA_FUNCTION_NAME=cloudwatch-to-slack
 AWS_REGION=us-west-2
 AWS_ROLE=arn:aws:iam::123456789123:role/lambda_exec_role
-AWS_PROFILE=myprofile
+AWS_PROFILE=default
 ```
 
-
-### 2. Configure AWS Lambda script
-
-Next, open `config.js`. there are several mandatory and optional
-configuration options. We've tried to choose a good set of defaults:
-
-
-#### a. mandatory configuration
-
-A hook URL and a `slackChannel` are required configurations. The
-`slackChannel` is the name of the Slack room to send the messages. To
-get the value for the URL, you'll need to set up a Slack hook,
-[as described below](#3-setup-slack-hook).
-
-To configure a proper Slack webhook URL, either the
-`kmsEncyptedHookUrl` or `unencryptedHookUrl` needs to be filled
-out. `kmsEncyptedHookUrl` uses the AWS KMS encryption service. See the
-documentation below for more details
-([unencrypted hook url](#unencrypted-hook-url) &
-[encrypted hook url](#encrypted-hook-url))
-
-
-#### b. optional configuration
-
-All other configuration options are "optional". Some customize the
-look and text in the Slack notification; `slackUsername` and `orgIcon`
-will enhance the messages appearance.
-
-
-### 3. Setup Slack hook
+### 2. Setup Slack hook
 
 Follow these steps to configure the webhook in Slack:
 
@@ -98,20 +69,23 @@ Follow these steps to configure the webhook in Slack:
   5. Click 'Save Settings' at the bottom of the Slack integration
      page.
 
-### 4. Deploy to AWS Lambda
+### 3. Configure AWS Lambda script
 
-The final step is to deploy the integration to AWS Lambda:
+Next, open `deploy.env.example`, there are several configuration
+options here. At a minimum, you must fill out `UNENCRYPTED_HOOK_URL`
+(or `KMS_ENCRYPTED_HOOK_URL`) and `SLACK_CHANNEL` (the name of the Slack room to send messages).
 
-    make deploy
+When you're done, copy the file to `deploy.env`:
 
-#### Unencrypted hook URL
+```
+$ cp deploy.env.example deploy.env
+```
+
+#### Encrypted the Slack webhook URL
 
 If you don't want or need to encrypt your hook URL, you can use the
-`unencryptedHookUrl`.  If this variable is specified, the
-kmsEncyptedHookUrl is ignored.
-
-
-#### Encrypted hook URL
+`UNENCRYPTED_HOOK_URL`.  If this variable is specified, the
+`KMS_ENCRYPTED_HOOK_URL` is ignored.
 
 Follow these steps to encrypt your Slack hook URL for use in this
 function:
@@ -149,6 +123,13 @@ function:
 }
 ```
 
+
+### 4. Deploy to AWS Lambda
+
+The final step is to deploy the integration to AWS Lambda:
+
+    make deploy
+
 ## Tests
 
 With the variables filled in, you can test the function:
@@ -157,6 +138,15 @@ With the variables filled in, you can test the function:
 npm install
 make test
 ```
+
+## Caveats
+
+- Environment variables specified in `deploy.env` may not show up on
+  AWS Lambda but are still in use.
+
+- `node-lambda` appends `-development` to Lambda function names. To
+  fix this, check out the `.env` file created by and set the
+  `AWS_ENVIRONMENT` var to an empty string, like `AWS_ENVIRONMENT=`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ If you don't want or need to encrypt your hook URL, you can use the
 `UNENCRYPTED_HOOK_URL`.  If this variable is specified, the
 `KMS_ENCRYPTED_HOOK_URL` is ignored.
 
-Follow these steps to encrypt your Slack hook URL for use in this
-function:
+If you **do** want to encrypt your hook URL, follow these steps to
+encrypt your Slack hook URL for use in this function:
 
   1. Create a KMS key -
      http://docs.aws.amazon.com/kms/latest/developerguide/create-keys.html.
@@ -145,8 +145,9 @@ make test
   AWS Lambda but are still in use.
 
 - `node-lambda` appends `-development` to Lambda function names. To
-  fix this, check out the `.env` file created by and set the
-  `AWS_ENVIRONMENT` var to an empty string, like `AWS_ENVIRONMENT=`
+  fix this, check out the `.env` file created by `node-lambda` and set
+  the `AWS_ENVIRONMENT` var to an empty string, like
+  `AWS_ENVIRONMENT=`
 
 ## License
 

--- a/config.js
+++ b/config.js
@@ -1,12 +1,12 @@
 module.exports = {
 
-  kmsEncryptedHookUrl: "<kmsEncryptedHookUrl>", // encrypted slack webhook url
-  unencryptedHookUrl: "<unencryptedHookUrl>", // unencrypted slack webhook url
-  slackChannel: "#general",  // slack channel to send a message to
-  slackUsername: "AWS SNS via Lamda", // slack username to user for messages
-  icon_emoji: ":robot_face:", // slack emoji icon to use for messages
-  orgIcon: "", // url to icon for your organization for display in the footer of messages
-  orgName: "", // name of your organization for display in the footer of messages
+  kmsEncryptedHookUrl: process.env.KMS_ENCRYPTED_HOOK_URL, // encrypted slack webhook url
+  unencryptedHookUrl: process.env.UNENCRYPTED_HOOK_URL,
+  slackChannel: process.env.SLACK_CHANNEL, // slack channel to send a message to
+  slackUsername: process.env.SLACK_USERNAME, // "AWS SNS via Lamda", // slack username to user for messages
+  icon_emoji: process.env.ICON_EMOJI, // slack emoji icon to use for messages
+  orgIcon: process.env.ORG_ICON,  // url to icon for your organization for display in the footer of messages
+  orgName: process.env.ORG_NAME, // name of your organization for display in the footer of messages
   services: {
     elasticbeanstalk: {
       match_text: "ElasticBeanstalkNotifications" // text in the sns message or topicname to match on to process this service type

--- a/config.js
+++ b/config.js
@@ -1,7 +1,7 @@
 module.exports = {
 
   kmsEncryptedHookUrl: process.env.KMS_ENCRYPTED_HOOK_URL, // encrypted slack webhook url
-  unencryptedHookUrl: process.env.UNENCRYPTED_HOOK_URL,
+  unencryptedHookUrl: process.env.UNENCRYPTED_HOOK_URL, // unencrypted slack webhook url
   slackChannel: process.env.SLACK_CHANNEL, // slack channel to send a message to
   slackUsername: process.env.SLACK_USERNAME, // "AWS SNS via Lamda", // slack username to user for messages
   icon_emoji: process.env.ICON_EMOJI, // slack emoji icon to use for messages

--- a/deploy.env.example
+++ b/deploy.env.example
@@ -1,7 +1,7 @@
 KMS_ENCRYPTED_HOOK_URL=
 UNENCRYPTED_HOOK_URL=
 SLACK_CHANNEL='#notifications'
-SLACK_USERNAME=Assertible
+SLACK_USERNAME=Slack-CloudWatch-Bot
 ICON_EMOJI=":robot_face:"
 ORG_ICON=https://assertible.com/images/logo/logo-64x64.png
 ORG_NAME=Assertible

--- a/deploy.env.example
+++ b/deploy.env.example
@@ -1,0 +1,7 @@
+KMS_ENCRYPTED_HOOK_URL=
+UNENCRYPTED_HOOK_URL=
+SLACK_CHANNEL='#notifications'
+SLACK_USERNAME=Assertible
+ICON_EMOJI=":robot_face:"
+ORG_ICON=https://assertible.com/images/logo/logo-64x64.png
+ORG_NAME=Assertible


### PR DESCRIPTION
This is an extension of #11 by @rnhurt (which should be merged first).

- Use `deploy.env` to store use configuration. `deploy.env` is
  supported by `node-lambda` for testing and deploying

- Add `deploy.env.example` for example configuration

- Update README

- Add new make rule for `test-all`. Only run one test using `make
  test`.