### PR TITLE
Encode alarm name in CloudWatch alarm URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ var handleCloudWatch = function(event, context) {
           { "title": "Current State", "value": newState, "short": true },
           {
             "title": "Link to Alarm",
-            "value": "https://console.aws.amazon.com/cloudwatch/home?region=" + region + "#alarm:alarmFilter=ANY;name=" + alarmName,
+            "value": "https://console.aws.amazon.com/cloudwatch/home?region=" + region + "#alarm:alarmFilter=ANY;name=" + encodeURIComponent(alarmName),
             "short": false
           }
         ],


### PR DESCRIPTION
Keeps the link working even if alarm name contains spaces or other special characters.