### PR TITLE
Support for mentions and links to CloudWatch logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ UNENCRYPTED_HOOK_URL=
 AWS_FUNCTION_NAME=
 AWS_REGION=eu-west-1
 AWS_ROLE="arn:aws:iam::123456789123:role/lambda_exec_role"
+MENTION=channel
 
 # You can get AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY here: https://console.aws.amazon.com/iam/home#/users
 # Click on user -> Security credentials -> Access keys -> Create access key

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@ UNENCRYPTED_HOOK_URL=
 AWS_FUNCTION_NAME=
 AWS_REGION=eu-west-1
 AWS_ROLE="arn:aws:iam::123456789123:role/lambda_exec_role"
-MENTION=channel
+# See message formatting for a guide on how to format mentions https://api.slack.com/docs/message-formatting
+MENTION=<!channel>
 
 # You can get AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY here: https://console.aws.amazon.com/iam/home#/users
 # Click on user -> Security credentials -> Access keys -> Create access key

--- a/config.js
+++ b/config.js
@@ -2,6 +2,8 @@ module.exports = {
   kmsEncryptedHookUrl: process.env.KMS_ENCRYPTED_HOOK_URL, // encrypted slack webhook url
   unencryptedHookUrl: process.env.UNENCRYPTED_HOOK_URL,    // unencrypted slack webhook url
 
+  mention: process.env.MENTION,
+
   services: {
     elasticbeanstalk: {
       // text in the sns message or topicname to match on to process this service type

--- a/index.js
+++ b/index.js
@@ -267,7 +267,7 @@ var handleCloudWatch = function(event, context) {
     var logGroupLinks = data.metricFilters
       .map(filter => ({
         "title": filter.filterName + " logs source",
-        "value": cloudwatchURLBase + "#logEventViewer:group=" + encodeURIComponent(filter.logGroupName) + ";filter=" + encodeURIComponent(filter.filterPattern) + ";start=PT" + trigger.EvaluationPeriods + "S",
+        "value": cloudwatchURLBase + "#logEventViewer:group=" + encodeURIComponent(filter.logGroupName) + ";filter=" + encodeURIComponent(filter.filterPattern) + ";start=PT" + trigger.Period + "S",
         "short": false
       }))
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var baseSlackMessage = {
   attachments: [
     {
       fields: config.mention ? [
-        { title: "Mention", value: "<!" + config.mention + ">", short: true }
+        { title: "Mention", value: config.mention, short: true }
       ] : []
     }
   ]

--- a/index.js
+++ b/index.js
@@ -5,7 +5,15 @@ var config = require('./config');
 var _ = require('lodash');
 var hookUrl;
 
-var baseSlackMessage = {}
+var baseSlackMessage = {
+  attachments: [
+    {
+      fields: config.mention ? [
+        { title: "Mention", value: "<!" + config.mention + ">", short: true }
+      ] : []
+    }
+  ]
+}
 
 var postMessage = function(message, callback) {
   var body = JSON.stringify(message);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lambda-cloudwatch-slack",
   "version": "0.3.0",
   "description": "Better Slack notifications for AWS CloudWatch",
-  "authors": [    
+  "authors": [
     "Christopher Reichert <creichert07@gmail.com>",
     "Cody Reichert <codyreichert@gmail.com>",
     "Alexandr Promakh <s-promakh@ya.ru>"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,5 +2,5 @@ NODE_LAMBDA=./node_modules/node-lambda/bin/node-lambda
 
 test -s $NODE_LAMBDA || { echo "node-lambda not installed. Run 'npm install' first."; exit 1; }
 mkdir -p tmp
-cat .env | grep HOOK_URL > ./tmp/deploy.env
+cat .env | grep -v AWS > ./tmp/deploy.env
 $NODE_LAMBDA deploy --configFile ./tmp/deploy.env


### PR DESCRIPTION
1. You can now configure whether to mention someone using `MENTION` environment variable.
2. If the CloudWatch alarm has been caused by a log metric filter, links to the appropriate logs will be included.