### PR TITLE
Fix the issue that alarm info part shows undefined when alarm is base…

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,18 +233,24 @@ var handleCloudWatch = function(event, context) {
   var region = event.Records[0].EventSubscriptionArn.split(":")[3];
   var subject = "AWS CloudWatch Notification";
   var alarmName = message.AlarmName;
-  var metricName = message.Trigger.MetricName;
   var oldState = message.OldStateValue;
   var newState = message.NewStateValue;
   var alarmDescription = message.AlarmDescription;
   var alarmReason = message.NewStateReason;
   var trigger = message.Trigger;
   var color = "warning";
+  var alarmConfigInfo;
 
   if (message.NewStateValue === "ALARM") {
       color = "danger";
   } else if (message.NewStateValue === "OK") {
       color = "good";
+  }
+
+  if (Array.isArray(trigger.Metrics) && trigger.Metrics.length > 0) {
+    alarmConfigInfo = "Expression based alarm";
+  } else {
+    alarmConfigInfo = trigger.Statistic + " " + trigger.MetricName;
   }
 
   var slackMessage = {
@@ -257,8 +263,7 @@ var handleCloudWatch = function(event, context) {
           { "title": "Alarm Description", "value": alarmDescription, "short": false},
           {
             "title": "Trigger",
-            "value": trigger.Statistic + " "
-              + metricName + " "
+            "value": alarmConfigInfo + " "
               + trigger.ComparisonOperator + " "
               + trigger.Threshold + " for "
               + trigger.EvaluationPeriods + " period(s) of "

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lambda-cloudwatch-slack",
   "version": "0.3.0",
   "description": "Better Slack notifications for AWS CloudWatch",
-  "authors": [    
+  "authors": [
     "Christopher Reichert <creichert07@gmail.com>",
     "Cody Reichert <codyreichert@gmail.com>",
     "Alexandr Promakh <s-promakh@ya.ru>"


### PR DESCRIPTION
When the alarm is created based on an expression of multiple metrics, the "Trigger.MetricName" will be undefined and shown in the slack message. It will make customers think that the alarm is not configured. The commit checks the if alarm is created based on expression, and reflect it to customers avoid the misleading undefined.