### PR TITLE
Add support Amazon ECS Event Stream for CloudWatch Events

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "lambda-cloudwatch-slack",
   "version": "0.3.0",
   "description": "Better Slack notifications for AWS CloudWatch",
-  "authors": [    
+  "authors": [
     "Christopher Reichert <creichert07@gmail.com>",
     "Cody Reichert <codyreichert@gmail.com>",
-    "Alexandr Promakh <s-promakh@ya.ru>"
+    "Alexandr Promakh <s-promakh@ya.ru>",
+    "Ramil Amerzyanov <ramilexe@gmail.com>"
   ],
   "config": {
     "progress": "true"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -11,3 +11,5 @@ $NODE_LAMBDA run -x test/context.json -j test/sns-codedeploy-event.json
 $NODE_LAMBDA run -x test/context.json -j test/sns-codedeploy-configuration.json
 $NODE_LAMBDA run -x test/context.json -j test/sns-elasticache-event.json
 $NODE_LAMBDA run -x test/context.json -j test/sns-autoscaling-event.json
+$NODE_LAMBDA run -x test/context.json -j test/sns-cloudwatch-event-ecs-stopped.json
+$NODE_LAMBDA run -x test/context.json -j test/sns-cloudwatch-event-ecs-pending.json

--- a/test/sns-cloudwatch-event-ecs-pending.json
+++ b/test/sns-cloudwatch-event-ecs-pending.json
@@ -1,0 +1,18 @@
+{
+  "Records": [
+    {
+      "EventSource": "aws:sns",
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:us-west-2:123456789123:CloudWatchNotifications:00000000-0000-0000-0000-000000000000",
+      "Sns": {
+        "Type": "Notification",
+        "MessageId": "00000000-0000-0000-0000-000000000000",
+        "TopicArn": "arn:aws:sns:us-west-2:123456789123:CloudWatchNotifications",
+        "Subject": null,
+        "Message": "{\"version\":\"0\",\"id\":\"5161328b-b6f8-c850-4e39-52e973dafd49\",\"detail-type\":\"ECS Task State Change\",\"source\":\"aws.ecs\",\"account\":\"000000000000\",\"time\":\"2019-09-19T13:26:12Z\",\"region\":\"us-east-1\",\"resources\":[\"arn:aws:ecs:us-east-1:000000000000:task/c08044ec-8b75-41ad-bdbb-8481e097fbae\"],\"detail\":{\"clusterArn\":\"arn:aws:ecs:us-east-1:000000000000:cluster/dev\",\"containerInstanceArn\":\"arn:aws:ecs:us-east-1:000000000000:container-instance/72609cd7-7211-4834-8120-b41c9d2234a9\",\"containers\":[{\"containerArn\":\"arn:aws:ecs:us-east-1:000000000000:container/b4d836b9-d9a1-4275-9536-b194b81d9930\",\"lastStatus\":\"PENDING\",\"name\":\"mycontainername\",\"taskArn\":\"arn:aws:ecs:us-east-1:000000000000:task/c08044ec-8b75-41ad-bdbb-8481e097fbae\",\"networkInterfaces\":[],\"cpu\":\"128\",\"memory\":\"128\"}],\"createdAt\":\"2019-09-19T13:26:12.237Z\",\"launchType\":\"EC2\",\"cpu\":\"128\",\"memory\":\"128\",\"desiredStatus\":\"RUNNING\",\"group\":\"service:mycontainername\",\"lastStatus\":\"PENDING\",\"overrides\":{\"containerOverrides\":[{\"name\":\"mycontainername\"}]},\"attachments\":[],\"startedBy\":\"ecs-svc/9223370467957936499\",\"updatedAt\":\"2019-09-19T13:26:12.237Z\",\"taskArn\":\"arn:aws:ecs:us-east-1:000000000000:task/c08044ec-8b75-41ad-bdbb-8481e097fbae\",\"taskDefinitionArn\":\"arn:aws:ecs:us-east-1:000000000000:task-definition/mycontainername:3\",\"version\":1}}",
+        "Timestamp": "2019-09-19T13:26:12.587Z",
+        "MessageAttributes": {}
+      }
+    }
+  ]
+}

--- a/test/sns-cloudwatch-event-ecs-stopped.json
+++ b/test/sns-cloudwatch-event-ecs-stopped.json
@@ -1,0 +1,18 @@
+{
+  "Records": [
+    {
+      "EventSource": "aws:sns",
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:us-west-2:123456789123:CloudWatchNotifications:00000000-0000-0000-0000-000000000000",
+      "Sns": {
+        "Type": "Notification",
+        "MessageId": "00000000-0000-0000-0000-000000000000",
+        "TopicArn": "arn:aws:sns:us-west-2:123456789123:CloudWatchNotifications",
+        "Subject": null,
+        "Message": "{\"version\":\"0\",\"id\":\"790f94d1-41c7-859d-68af-7d040bc2ca9f\",\"detail-type\":\"ECS Task State Change\",\"source\":\"aws.ecs\",\"account\":\"000000000000\",\"time\":\"2019-09-19T13:25:44Z\",\"region\":\"us-east-1\",\"resources\":[\"arn:aws:ecs:us-east-1:000000000000:task/4097e8a3-3989-41d4-9494-81f97a2cb74d\"],\"detail\":{\"clusterArn\":\"arn:aws:ecs:us-east-1:000000000000:cluster/dev\",\"containerInstanceArn\":\"arn:aws:ecs:us-east-1:000000000000:container-instance/72609cd7-7211-4834-8120-b41c9d2234a9\",\"containers\":[{\"containerArn\":\"arn:aws:ecs:us-east-1:000000000000:container/dd3b6843-b5d1-401a-a319-6c8d8574017d\",\"exitCode\":137,\"lastStatus\":\"STOPPED\",\"name\":\"mycontainername\",\"runtimeId\":\"a01ca4d3390aae111d96e99d2759e346c5f3aed60560d4d8d2f9d4afa313a191\",\"taskArn\":\"arn:aws:ecs:us-east-1:000000000000:task/4097e8a3-3989-41d4-9494-81f97a2cb74d\",\"networkInterfaces\":[],\"cpu\":\"128\",\"memory\":\"128\"}],\"createdAt\":\"2019-09-19T13:19:41.935Z\",\"launchType\":\"EC2\",\"cpu\":\"128\",\"memory\":\"128\",\"desiredStatus\":\"STOPPED\",\"group\":\"service:mycontainername\",\"lastStatus\":\"STOPPED\",\"overrides\":{\"containerOverrides\":[{\"name\":\"mycontainername\"}]},\"attachments\":[],\"connectivity\":\"CONNECTED\",\"connectivityAt\":\"2019-09-19T13:19:41.935Z\",\"pullStartedAt\":\"2019-09-19T13:19:42.79Z\",\"startedAt\":\"2019-09-19T13:19:42.79Z\",\"startedBy\":\"ecs-svc/9223370467957936499\",\"stoppingAt\":\"2019-09-19T13:25:44.03Z\",\"stoppedAt\":\"2019-09-19T13:25:44.03Z\",\"pullStoppedAt\":\"2019-09-19T13:19:42.79Z\",\"executionStoppedAt\":\"2019-09-19T13:25:44Z\",\"stoppedReason\":\"Essential container in task exited\",\"stopCode\":\"EssentialContainerExited\",\"updatedAt\":\"2019-09-19T13:25:44.03Z\",\"taskArn\":\"arn:aws:ecs:us-east-1:000000000000:task/4097e8a3-3989-41d4-9494-81f97a2cb74d\",\"taskDefinitionArn\":\"arn:aws:ecs:us-east-1:000000000000:task-definition/mycontainername:3\",\"version\":3}}",
+        "Timestamp": "2019-09-19T13:25:44.297Z",
+        "MessageAttributes": {}
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Added support for [ECS Event Stream](https://docs.aws.amazon.com/en_pv/AmazonECS/latest/developerguide/cloudwatch_event_stream.html)

That's how notifications look:

![image](https://user-images.githubusercontent.com/1008882/65281965-6e815080-db3c-11e9-80dd-f7d2fe265c46.png)

and

![image](https://user-images.githubusercontent.com/1008882/65281991-82c54d80-db3c-11e9-8209-d15bba10806a.png)
