### PR TITLE
Update  Runtime to 'nodejs16.x' to fix AWS deploy 15-Ag-2024

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
     "progress": "true"
   },
   "dependencies": {
-    "aws-sdk": "^2.4.0",
+    "aws-sdk": "^2.1595.0",
     "https": "^1.0.0",
-    "lodash": "^4.15.0",
-    "url": "^0.11.0"
+    "lodash": "^4.17.21",
+    "url": "^0.11.4"
   },
   "devDependencies": {
-    "node-lambda": "0.16.0"
+    "node-lambda": "1.3.0"
   },
   "keywords": [
     "aws",


### PR DESCRIPTION
"aws-sdk": "^2.1595.0"
"https": "^1.0.0"
"lodash": "^4.17.21"
"url": "^0.11.4"
"node-lambda": "1.3.0"